### PR TITLE
Ping backend to wake up heroku instance

### DIFF
--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -61,8 +61,12 @@
 </template>
 
 <script>
+  import { mapActions } from 'vuex';
   export default {
     name: 'intro',
+    mounted () {
+      this.pingBackend();
+    },
     data () {
       return {
         page: 0,
@@ -77,6 +81,9 @@
     computed: {
     },
     methods: {
+      ...mapActions([
+        'pingBackend',
+      ]),
       incrementPage () {
         ++this.page
         if (this.page === 1) {

--- a/src/services/ping.js
+++ b/src/services/ping.js
@@ -1,0 +1,7 @@
+import apiAxios from './index';
+
+export function ping() {
+  return apiAxios.get('ping/').then((response) => {
+    return response.data.message;
+  });
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import { generateQuiz } from '../services/quizes';
+import { ping } from '../services/ping';
 
 Vue.use(Vuex)
 
@@ -20,6 +21,9 @@ export default new Vuex.Store({
         context.commit('loadQuiz', {quiz})
       })
     },
+    pingBackend () {
+      ping();
+    }
   },
   mutations: {
     loadQuiz (state, { quiz }) {


### PR DESCRIPTION
Jeśli instacja Heroku nie jest używana, jest "usypiana". Kolejne zapytanie powoduje obudzenie instancji, ale trwa to 30s. Aby uniknąć czekania na odpowiedź w przypadku gdy instancja śpi, wysyłamy "ping" podczas startu aplikacji, żeby instancja zdążyła się podnieść przed zapytaniem generującym quiz.