### PR TITLE
fix safari number input

### DIFF
--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -25,6 +25,8 @@
         ref="prediction"
         v-model="userInfo.prediction"
         type="number"
+        inputmode="numeric"
+        pattern="[0-9]*"
         min="1"
         max="100"
         step="1"


### PR DESCRIPTION
Nie mam safari to nie mogę sprawdzić czy to pomogło, ale sugerowałem się
https://stackoverflow.com/questions/45096670/input-type-number-not-working-on-ipad