### PR TITLE
Disable Next button in AnswersReview when content not scrolled

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,7 @@ export default {
   --color-white: #FFFFFF;
   --color-gray: #ebf1f4;
   --color-gray-text: #9dabbc;
+  --color-dark-gray: #9dabbc;
 }
 html, option, input {
   font-family: 'Rubik', sans-serif;


### PR DESCRIPTION
Nie udało mi się ustalić, czy istnieje analog do eventu windowscroll, tylko że dla danego elementu; stąd rozwiązanie opierające się na obliczaniu tej pozycji co 200ms.